### PR TITLE
send header and message together 

### DIFF
--- a/SimpleWebSocketServer.py
+++ b/SimpleWebSocketServer.py
@@ -298,12 +298,12 @@ class WebSocket(object):
 				b2 |= 127
 				header.append(b2)
 				header.extend(struct.pack("!Q", length))
-		
-			self.sendBuffer(header)
-			header = None
 
 			if length > 0:
-				self.sendBuffer(s)
+				self.sendBuffer(header + s) 
+			else:
+				self.sendBuffer(header)
+			header = None
 
 		else:
 			msg = bytearray()			


### PR DESCRIPTION
Hi,
I was using your websocket implementation and when I'd send two messages in a short period of time (initiated simultaneously), I'd often get an error "Could not decode a text frame as UTF-8" in Google Chrome. I believe this was because you are sending header and message buffers sequentially. I made changes to send them as a concatenated message and it seems working fine. Do you think there are any problems with my solution?
Cheers
