### PR TITLE
Only include sockets in the writers of select that actually want to send something.

### DIFF
--- a/SimpleWebSocketServer/SimpleWebSocketServer.py
+++ b/SimpleWebSocketServer/SimpleWebSocketServer.py
@@ -577,7 +577,16 @@ class SimpleWebSocketServer(object):
 
    def serveforever(self):
       while True:
-         rList, wList, xList = select(self.listeners, self.listeners, self.listeners, 3)	
+         writers = []
+         for fileno in self.listeners:
+            try:
+               client = self.connections[fileno]
+               if client.sendq:
+                  writers.append(fileno)
+            except Exception as n:
+               pass
+         
+         rList, wList, xList = select(self.listeners, writers, self.listeners)
          
          for ready in wList:
             client = None


### PR DESCRIPTION
This together without a timeout on select reduces CPU load from 100% to 0% when nothing is exchanged.