### PR TITLE
Poor man's channel hack

### DIFF
--- a/SimpleWebSocketServer/SimpleExampleServer.py
+++ b/SimpleWebSocketServer/SimpleExampleServer.py
@@ -23,7 +23,7 @@ class SimpleChat(WebSocket):
 
    def handleMessage(self):
       for client in clients:
-         if client != self:
+         if client != self and client.request.path == self.request.path:
             client.sendMessage(self.address[0] + u' - ' + self.data)
 
    def handleConnected(self):


### PR DESCRIPTION
A path in the URL of the Websockets server acts as a 'channel' - useful for isolating clients from one another.

e.g:
```
ws_url = 'ws://localhost:8000/channel1'
```
will only pass messages between the clients on the same channel