### PR TITLE
use ssl contexts to enable privilege dropping

### DIFF
--- a/SimpleWebSocketServer/SimpleWebSocketServer.py
+++ b/SimpleWebSocketServer/SimpleWebSocketServer.py
@@ -718,19 +718,14 @@ class SimpleSSLWebSocketServer(SimpleWebSocketServer):
 
       SimpleWebSocketServer.__init__(self, host, port, websocketclass)
 
-      self.cerfile = certfile
-      self.keyfile = keyfile
-      self.version = version
+      self.context = ssl.SSLContext(version)
+      self.context.load_cert_chain(certfile, keyfile)
 
    def close(self):
       super(SimpleSSLWebSocketServer, self).close()
 
    def _decorateSocket(self, sock):
-      sslsock = ssl.wrap_socket(sock,
-                           server_side=True,
-                           certfile=self.cerfile,
-                           keyfile=self.keyfile,
-                           ssl_version=self.version)
+      sslsock = self.context.wrap_socket(sock, server_side=True)
       return sslsock
 
    def _constructWebSocket(self, sock, address):


### PR DESCRIPTION
Using ssl.wrap_socket requires that any applications using this must maintain root privileges, and dropping privileges (e.g. via `os.setuid`) results in permission errors whenever a socket is created. SSLContexts to the rescue!

By creating an SSLContext and reading in the certificate and key, applications which use `SimpleSSLWebSocketServer` can safely drop root privileges after creating the SimpleSSLWebSocketServer object.