### PR TITLE
Fixed SSL typo

### DIFF
--- a/SimpleWebSocketServer/SimpleExampleServer.py
+++ b/SimpleWebSocketServer/SimpleExampleServer.py
@@ -49,6 +49,7 @@ if __name__ == "__main__":
    parser.add_option("--example", default='echo', type='string', action="store", dest="example", help="echo, chat")
    parser.add_option("--ssl", default=0, type='int', action="store", dest="ssl", help="ssl (1: on, 0: off (default))")
    parser.add_option("--cert", default='./cert.pem', type='string', action="store", dest="cert", help="cert (./cert.pem)")
+   parser.add_option("--key", default='./key.pem', type='string', action="store", dest="key", help="key (./key.pem)")
    parser.add_option("--ver", default=ssl.PROTOCOL_TLSv1, type=int, action="store", dest="ver", help="ssl version")
 
    (options, args) = parser.parse_args()
@@ -58,7 +59,7 @@ if __name__ == "__main__":
       cls = SimpleChat
 
    if options.ssl == 1:
-      server = SimpleSSLWebSocketServer(options.host, options.port, cls, options.cert, options.cert, version=options.ver)
+      server = SimpleSSLWebSocketServer(options.host, options.port, cls, options.cert, options.key, version=options.ver)
    else:
       server = SimpleWebSocketServer(options.host, options.port, cls)
 


### PR DESCRIPTION
Based on the other examples, it looks like the ssl key file needs to be included as well as the cert. I added a command line option `--key` for that. Also, the SSL server was being given the cert file twice. This works for me now. Thanks for the great ws examples!