### PR TITLE
SimpleWebSocketServer: honor selectInterval=0

### DIFF
--- a/SimpleWebSocketServer/SimpleWebSocketServer.py
+++ b/SimpleWebSocketServer/SimpleWebSocketServer.py
@@ -614,10 +614,7 @@ class SimpleWebSocketServer(object):
          if client.sendq:
             writers.append(fileno)
 
-      if self.selectInterval:
-         rList, wList, xList = select(self.listeners, writers, self.listeners, self.selectInterval)
-      else:
-         rList, wList, xList = select(self.listeners, writers, self.listeners)
+      rList, wList, xList = select(self.listeners, writers, self.listeners, self.selectInterval)
 
       for ready in wList:
          client = self.connections[ready]


### PR DESCRIPTION
Currently for selectInterval=0 case, SimpleWebSocketServer removes the argument completely from the `select()` call, which means "no timeout".  For wrapping SimpleWebSocketServer in an async library, it's useful to support a timeout of 0 so that select returns immediately.

The cited behavior has been removed, so that selectInterval=0 and selectInterval=None are passed as-is to `select()`.  The default value of .1 seconds is unchanged.