### PR TITLE
Fixed incorrect spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Chat Server (open up multiple *websocket.html* files)
 
     openssl req -new -x509 -days 365 -nodes -out cert.pem -keyout key.pem
 
-2) Run the secure TSL/SSL server (in this case the cert.pem file is in the same directory)
+2) Run the secure TLS/SSL server (in this case the cert.pem file is in the same directory)
 
     python SimpleExampleServer.py --example chat --ssl 1 --cert ./cert.pem
 


### PR DESCRIPTION
TSL/SSL is incorrect. Corrected to TLS/SSL