### PR TITLE
Fix hang in SSL do_handshake and rework server shutdown routine 

### DIFF
--- a/SimpleWebSocketServer/SimpleWebSocketServer.py
+++ b/SimpleWebSocketServer/SimpleWebSocketServer.py
@@ -637,9 +637,11 @@ class SimpleWebSocketServer(object):
       return self.websocketclass(self, sock, address)
 
    def close(self):
-      self.serversocket.close()
-      self.listeners.remove(self.serversocket)
+      serversocket = self.serversocket
       self.serversocket = None
+      self.listeners.remove(serversocket)
+      serversocket.close()
+      serversocket = None
 
       for desc, client in self.connections.items():
          # queue the CLOSE command


### PR DESCRIPTION
I was having a problem with the server hanging and not accepting new connections.  I tracked it down to connections which have been opened but then do not complete a SSL/TLS handshake.  It can be reproduced by simply opening a TCP connection and then not sending anything; example python:

```
~$ python3

Python 3.11.2 (main, May  2 2024, 11:59:08) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.

>>> import socket
>>> s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
>>> s.connect(('MY IP', PORT))
>>> 
```
The server is now hung and no other connection can be opened.

Closes #13 

I also reworked the server shutdown code so it actually sends the CLOSE command it queues up.

Closes #85 